### PR TITLE
Fix startup problems with apt and usernames

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,12 +14,12 @@ Follow the steps and run the commands
 You just need to have docker installed and have your user be in the `docker` group
 Since it's written in Bash, it should work on any version of Linux
 ## How it works
- The setup of all the containers is done by the `init.sh` script, it does the following steps every time when ran:
- 1.  Builds all the images from the dockerfiles in `children/*/Dockerfile`  
+The setup of all the containers is done by the `init.sh` script, it does the following steps every time when ran:
+1. Builds all the images from the dockerfiles in `children/*/Dockerfile`  
 2. Builds the master image and copies all the images built in the previous step into it
 3. Runs the master container
 
- The `setup` script runs inside the `master` container
+The `setup` script runs inside the `master` container
 
 4. Installs docker (This step will be moved into the dockerfile in future releases )
 5. Loads the images into docker

--- a/dosh
+++ b/dosh
@@ -1,5 +1,5 @@
 #!/bin/bash
-sudo docker run \
+sudo /usr/bin/dockerc run \
 --memory=256m \
 --memory-swap=256m \
 --kernel-memory=128m \

--- a/init.sh
+++ b/init.sh
@@ -49,13 +49,13 @@ else
 fi
 
 # Run the master container
-#docker run -it \
-#    -p 2002:22 \
-#    --name=$master_container_name \
-#    --restart=unless-stopped \
-#    -v /var/run/docker.sock:/var/run/docker.sock \
-#    -v $(which docker):/usr/bin/dockerc \
-#    $master_image_name
+docker run -it \
+    -p 2002:22 \
+    --name=$master_container_name \
+    --restart=unless-stopped \
+    -v /var/run/docker.sock:/var/run/docker.sock \
+    -v $(which docker):/usr/bin/dockerc \
+    $master_image_name
 
 # LOG
 echo "@@@Started master container $master_container_name successfully"

--- a/init.sh
+++ b/init.sh
@@ -41,7 +41,7 @@ docker build -t $master_image_name .
 echo "@@@Built master image $master_image_name successfully"
 
 # If the argument is "r", remove the old master container
-if [ "$1" = "-r" ]; then
+if [ "$1" = "r" ]; then
     docker rm -f $master_container_name
     echo "@@@Removed old master container successfully"
 else

--- a/init.sh
+++ b/init.sh
@@ -41,7 +41,7 @@ docker build -t $master_image_name .
 echo "@@@Built master image $master_image_name successfully"
 
 # If the argument is "r", remove the old master container
-if [ "$1" = "r" ]; then
+if [ "$1" = "-r" ]; then
     docker rm -f $master_container_name
     echo "@@@Removed old master container successfully"
 else
@@ -49,13 +49,13 @@ else
 fi
 
 # Run the master container
-docker run -it \
--p 2002:22 \
---name=$master_container_name \
---restart=unless-stopped \
--v /var/run/docker.sock:/var/run/docker.sock \
--v $(which docker):/usr/bin/dockerc \
-$master_image_name
+#docker run -it \
+#    -p 2002:22 \
+#    --name=$master_container_name \
+#    --restart=unless-stopped \
+#    -v /var/run/docker.sock:/var/run/docker.sock \
+#    -v $(which docker):/usr/bin/dockerc \
+#    $master_image_name
 
 # LOG
 echo "@@@Started master container $master_container_name successfully"

--- a/setup
+++ b/setup
@@ -5,12 +5,8 @@
 # Stop the script on command error
 set -e
 
-echo set!
-
 # Set the directory for the source of the child images
 image_directory="/mnt/images/"
-
-echo image!
 
 # Install docker
 #sudo apt install docker.io -y
@@ -18,13 +14,10 @@ echo image!
 # For each image in the image directory
 #for image_path in $(find "$image_directory" -maxdepth 1  -type f); do
 for image_path in /mnt/images/*.tar; do
-    echo "for $image_path"
     # Load the image into docker
     sudo /usr/bin/dockerc load < "$image_path"
-    echo loaded!
     # Get the name of the image for user creation
     name=$(echo "$image_path" | sed "s|^$image_directory||" | sed "s|^virtssh-children||" | sed "s|\.tar$||"  )
-    echo "got $name"
     # LOG
     echo "Attempting to create user: $name"
 

--- a/setup
+++ b/setup
@@ -23,7 +23,7 @@ for image_path in /mnt/images/*.tar; do
     sudo /usr/bin/dockerc load < "$image_path"
     echo loaded!
     # Get the name of the image for user creation
-    name=$(echo "$image_path" | sed "s|^$image_directory/virtssh-children||" | sed "s|\.tar$||"  )
+    name=$(echo "$image_path" | sed "s|^$image_directory||" | sed "s|^virtssh-children||" | sed "s|\.tar$||"  )
     echo "got $name"
     # LOG
     echo "Attempting to create user: $name"

--- a/setup
+++ b/setup
@@ -5,21 +5,26 @@
 # Stop the script on command error
 set -e
 
+echo set!
+
 # Set the directory for the source of the child images
 image_directory="/mnt/images/"
 
+echo image!
+
 # Install docker
-sudo apt install docker.io -y
+#sudo apt install docker.io -y
 
 # For each image in the image directory
-for image_path in $(find "$image_directory" -maxdepth 1  -type f); do
-
+#for image_path in $(find "$image_directory" -maxdepth 1  -type f); do
+for image_path in /mnt/images/*.tar; do
+    echo "for $image_path"
     # Load the image into docker
-    sudo docker load < "$image_path"
-
+    sudo /usr/bin/dockerc load < "$image_path"
+    echo loaded!
     # Get the name of the image for user creation
-    name=$(echo "$image_path" | sed "s|^$image_directory||" |  sed "s|\.tar$||"  )
-
+    name=$(echo "$image_path" | sed "s|^$image_directory/virtssh-children||" | sed "s|\.tar$||"  )
+    echo "got $name"
     # LOG
     echo "Attempting to create user: $name"
 
@@ -31,7 +36,7 @@ for image_path in $(find "$image_directory" -maxdepth 1  -type f); do
     sudo adduser $name sudo
 
     # LOG
-    echo "Created user: $name, from image: $image_path"
+    echo "Created user: $name, from image: $image_path";
 
 done
 


### PR DESCRIPTION
This PR fixes an issue when apt crashes while installing docker.io by using the passed docker binary rather than install docker in the conteiner.

It also fixes a problem where the image file `virtssh-childrendemo.tar` would result in a user named `virtssh-childrendemo` instead of `demo`.